### PR TITLE
Remove warning

### DIFF
--- a/lib/atomic-management.js
+++ b/lib/atomic-management.js
@@ -202,11 +202,11 @@ export default {
       contents = {};
     }
 
-    const currDisabled = this.getDisabledPackages(this.configContents);
-    const newDisabled = this.getDisabledPackages(contents);
-    if (this.configContents && !this.compareArrays(currDisabled, newDisabled)) {
-      this.askReload();
-    }
+    // const currDisabled = this.getDisabledPackages(this.configContents);
+    // const newDisabled = this.getDisabledPackages(contents);
+    // if (this.configContents && !this.compareArrays(currDisabled, newDisabled)) {
+    //   this.askReload();
+    // }
 
     const installedPackageNames = new Set(
       atom.packages.getAvailablePackageNames()


### PR DESCRIPTION
No longer need warning on new disabled packages - Atom handles this poorly in the first place