### PR TITLE
Get atom to reset back to default correctly

### DIFF
--- a/.atom/config.cson
+++ b/.atom/config.cson
@@ -1,4 +1,10 @@
 "*":
+    core:
+        themes:
+            [
+                "one-light-ui",
+                "one-light-syntax",
+            ]
     editor:
         fontSize: 16
         tabLength: 2

--- a/lib/atomic-management.js
+++ b/lib/atomic-management.js
@@ -419,10 +419,8 @@ export default {
    * configuration.
    */
   restoreGlobalConfig() {
-    atom.config.resetProjectSettings(
-      {},
-      null
-    );
+    atom.config.resetProjectSettings ({}, true)
+    atom.config.clearProjectSettings();
     this.currentConfig=null;
     this.configuredFields.clear();
     this.updateStatusBar()


### PR DESCRIPTION
Tiny change - right now if we remove project folders or configs, we reset to global settings improperly (not imperatively). This forces it to do that (with a bit of a trick).