### PR TITLE
Fixed properly querying packages in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ you wish to change global settings, directly edit the global configuration
 either through `Edit > Config` on Windows/Linux or `Atom > Config` on Mac.
 
 ### How do I reset my choice of which per-project config file to use?
-In `Packages > atomic-management`, select the option `Reset Remembered Config`.
+In `Packages > Atomic Management`, select the option `Reset Remembered Config`.
 
 ### How do I tell which per-project config file is currently in effect?
 You can quickly open up the active per-project config file by selecting
-`Packages > atomic-management > Open Active Config File`.
+`Packages > Atomic Management > Open Active Config File`.
 
 ### Can different keybindings be set with this package?
 No. This package only manages settings that are available through Atom's

--- a/lib/atomic-management.js
+++ b/lib/atomic-management.js
@@ -450,7 +450,7 @@ export default {
     }
 
     if (notInstalledPackageNames.length !== 0) {
-      this.askInstallPackages(notInstalledPackageNames);
+      this.checkPackages(notInstalledPackageNames);
     }
 
     this.config = this.projectConfigs[0];

--- a/lib/atomic-management.js
+++ b/lib/atomic-management.js
@@ -222,7 +222,7 @@ export default {
     }
 
     if (notInstalledPackageNames.length !== 0) {
-      this.askInstallPackages(notInstalledPackageNames);
+      this.checkPackages(notInstalledPackageNames);
     }
 
     this.config = configName;
@@ -534,6 +534,69 @@ export default {
     this.currentConfig=null;
     this.configuredFields.clear();
     this.updateStatusBar()
+  },
+
+  alertBadPackages(packageNames){
+    const message = 'Invalid Package Names';
+    const description =
+      'The following packages are configured in the local project ' +
+      'configuration file but are invalid packages. Please fix your config file.\n\n' + 
+      packageNames.map(name => `- ${name}`).join('\n');
+
+    const notification = atom.notifications.addWarning(message, {
+      description,
+      dismissable: true
+    });
+  },
+
+  /**
+    * Checks existence of packages specified using apm view. Will silently ignore
+    * any package names that contain spaces, because that is invalid.
+    *
+    * @param {Array<String>} packageNames The package names to install
+    */
+  checkPackages(packageNames) {
+    // ignore any package names that contain spaces
+    origPackageNames = packageNames.slice();
+    packageNames = packageNames.filter(name => name.indexOf(' ') === -1);
+
+    if (packageNames.length === 0) {
+      this.alertBadPackages(origPackageNames);
+      return;
+    }
+
+    const viewPromises = [];
+
+    const command = atom.packages.getApmPath();
+    const stdout = output => console.log(output);
+
+    packageNames.forEach(name => {
+      const args = ['view', name];
+
+      let exit;
+      const myPromise = new Promise((resolve, reject) => {
+        exit = code => {
+          resolve({packageName: name, code: code})
+        }
+      });
+
+      viewPromises.push(myPromise);
+
+      const process = new BufferedProcess({ command, args, stdout, exit });
+    });
+
+    Promise.all(viewPromises)
+      .then(allResults => {
+        const successful = allResults
+                          .filter(r => r.code === 0)
+                          .map(r => r.packageName);
+
+        if (successful.length > 0) {
+          this.askInstallPackages(successful);
+        } else {
+          this.alertBadPackages(origPackageNames);
+        }
+      });
   },
 
   /**


### PR DESCRIPTION
Flow is like so:
- Checks if any of the non-installed packages are invalid
- if any are VALID, then prompt to install those valid only, then prompt reload
- if all are INVALID, then popup with warning
So - we can potentially have flows like:
"Install good-package?" - yes - "done" - reload - "you have a bad package"
We may or may not want to go over this flow?