### PR TITLE
removes check for file extension

### DIFF
--- a/lib/atomic-management.js
+++ b/lib/atomic-management.js
@@ -18,8 +18,6 @@
  * .atom/config.cson file.
  */
 
-// requires fs, glob, season libraries and assigned them as constants.
-const fs = require('fs');
 const glob = require('glob');
 const CSON = require('season');
 const mergeJSON = require("merge-json") ;
@@ -134,7 +132,7 @@ export default {
    * `atomic-management.isEnabled`. If the package is toggled off, the global
    * configuration settings will be restored. If the package is toggled on,
    * local configuration settings, if any, will go into effect.
-   * 
+   *
    * @param {Boolean} newValue The new value of `atomic-management.isEnabled`
    */
   enabledChanged(newValue){
@@ -180,12 +178,7 @@ export default {
     let contents;
 
     try {
-      if (configName.endsWith('.cson')) {
-        contents = CSON.readFileSync(configName);
-      } else if (configName.endsWith('.json')) {
-        contents = JSON.parse(fs.readFileSync(configName));
-      }
-
+      contents = CSON.readFileSync(configName);
       contents = this.standardizeConfig(contents);
     } catch (e) {
       atom.notifications.addWarning(
@@ -402,12 +395,7 @@ export default {
     this.projectConfigs.forEach(configName => {
       let contents;
       try {
-        if (configName.endsWith('.cson')) {
-          contents = CSON.readFileSync(configName);
-        } else if (configName.endsWith('.json')) {
-          contents = JSON.parse(fs.readFileSync(configName));
-        }
-
+        contents = CSON.readFileSync(configName);
         contents = this.standardizeConfig(contents);
       } catch (e) {
         atom.notifications.addWarning(
@@ -599,7 +587,7 @@ export default {
   /**
    * Adds global namespace to configuration object if it does not use
    * namespaces.
-   * 
+   *
    * @param {Object} config A configuration object
    */
   standardizeConfig(config) {


### PR DESCRIPTION
Turns out Season handles both JSON and CSON so we don't need to do these extra file extension checks

https://github.com/atom/season#csonreadfilesyncobjectpath